### PR TITLE
Correct File Extension in IRI

### DIFF
--- a/.github/linteddata.yaml
+++ b/.github/linteddata.yaml
@@ -10,7 +10,6 @@ checks:
     MissingDescriptionCheck: false
     MissingLabelCheck: false
   OWL:
-    FileExtensionInIriCheck: false
     OntologyIriOboConformanceCheck: false
     SynonymsAsClassesCheck: false
     UnconnectedClassCheck: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
   build-panet:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.13
+      image: gitlab.desy.de:5555/paul.millar/panet-build:7-updates-for-fileextensioniniricheck-in-panet
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
# Motivation

We started using the checks provided by LintedData and had to suppress several checks in the beginning in order to make our pipeline pass. We will take care of these checks one by one, activating them inorder to improve PaNET in the long run. Here we focus on the file extension in the IRI.

# Modification

The check has been activated (by deleting the line in linteddata.yaml). The pipeline has been updated to use the new version of panet-build, which solves the issue.

# Result

The pipeline passes.

# Related Issues

closes #470