### PR TITLE
Add versionIRI to metadata in build step

### DIFF
--- a/.github/linteddata.yaml
+++ b/.github/linteddata.yaml
@@ -5,8 +5,6 @@ checks:
     SeparatorOmittedInNamespaceCheck: false
   RDFS:
     UnconnectedClassCheck: false
-    VersionIriExistenceCheck: false
-    LeadingOrTrailingSpaceCheck: true
     MissingDescriptionCheck: false
     MissingLabelCheck: false
   OWL:
@@ -14,4 +12,3 @@ checks:
     OntologyIriOboConformanceCheck: false
     SynonymsAsClassesCheck: false
     UnconnectedClassCheck: false
-    VersionIriExistenceCheck: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
   build-panet:
     runs-on: ubuntu-latest
     container:
-      image: gitlab.desy.de:5555/paul.millar/panet-build:v0.13
+      image: gitlab.desy.de:5555/paul.millar/panet-build:6-versioninfo-iri
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
# Motivation

We started using the checks provided by LintedData and had to suppress several checks in the beginning in order to make our pipeline pass. We will take care of these checks one by one, activating them inorder to improve PaNET in the long run. Here we focus on the version IRI.

# Modification

The build script has been updated to set the versionIRI. Pipeline has been updated to use the correct build image. The check has been disabled.

# Result

More active linter checks.

# Related Issues

closes #469