### PR TITLE
Improve missing label check for metadata

### DIFF
--- a/source/PaNET_metadata.ttl
+++ b/source/PaNET_metadata.ttl
@@ -9,6 +9,30 @@
 @prefix vann: <http://purl.org/vocab/vann/>.
 @base <http://purl.org/pan-science/PaNET/PaNET.owl> .
 
+dcterms:created rdfs:label "Creation Date"@en .
+
+dcterms:creator rdfs:label "Creator"@en .
+
+dcterms:license rdfs:label "License"@en .
+
+dcterms:title rdfs:label "Title"@en .
+
+foaf:homepage rdfs:label "Homepage"@en .
+
+foaf:name rdfs:label "Name"@en .
+
+foaf:Person rdfs:label "Person"@en .
+
+foaf:workInfoHomepage rdfs:label "Work Info Homepage"@en .
+
+sdo:affiliation rdfs:label "Affiliation"@en .
+
+sdo:name rdfs:label "Name"@en .
+
+vann:preferredNamespacePrefix rdfs:label "Preferred Namespace Prefix"@en .
+
+vann:preferredNamespaceUri rdfs:label "Preferred Namespace URI"@en .
+
 <http://purl.org/pan-science/PaNET/PaNET.owl>
   a owl:Ontology ;
   dcterms:created "2025-10-21"^^xsd:string ; 


### PR DESCRIPTION
# Motivation

We started using the checks provided by LintedData and had to suppress several checks in the beginning in order to make our pipeline pass. We will take care of these checks one by one, activating them inorder to improve PaNET in the long run. Here we focus on missing class and property labels for metadata.

# Modification

Added explicit class descriptions including a label in the header of PaNET_metadata.ttl.

# Result

Only 3 classes fail the check, all of them from the data file PaNET.csv.

# Related Issues

closes #475